### PR TITLE
Auto-generate OG images for blog posts from titles

### DIFF
--- a/docs/og-image-based-on-title.md
+++ b/docs/og-image-based-on-title.md
@@ -1,0 +1,11 @@
+# Base OG image for blog posts on post titles
+
+This document outlines an idea for generating the OG images for blog posts on the website such that they inlcude the post title along with an image of me.
+
+## Desired outcome
+
+Whenever I share a blog post from this site to social media, I would like it to be automatically generated and show the title of the post along with the same image of me that I use on the home page of the website (round in shape) with a back ground color that is the same as the dark mode of site. It should use the same IBM Plex fonts as used on the site, using the one that is used for the page headers.
+
+## Workflow
+
+I would like the generation of the image to take place during build time of the site. It should happen regardless of whether I'm building locally or deploying the site. Once it is generated, it should not be re-generated on subsequent rebuilds, unless I change the title during development mode.

--- a/docs/superpowers/plans/2026-05-05-og-image-from-title.md
+++ b/docs/superpowers/plans/2026-05-05-og-image-from-title.md
@@ -1,0 +1,916 @@
+# OG Image From Title — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate a per-post Open Graph PNG (1200×630, post title + round profile photo on dark background) at build time for every post in `collections.posts` not tagged `notes` or `til`, cached by title hash so unchanged posts don't re-render.
+
+**Architecture:** A self-contained module under `src/_config/og-image/` registers two hooks on Eleventy: an `addCollection` callback that captures matching posts during the data cascade, and an `eleventy.after` event that renders/caches PNGs into `_site/assets/img/og/`. Posts get a new computed `ogImage` property in their data; `head.njk` reads `ogImage` for the `og:image` meta tag while leaving `image` (the in-body hero) untouched.
+
+**Tech Stack:** Eleventy v4 (alpha), Node ESM, [Satori](https://github.com/vercel/satori) (HTML-to-SVG renderer), [sharp](https://sharp.pixelplumbing.com/) (SVG-to-PNG, already a transitive dep), [@fontsource/ibm-plex-serif](https://www.npmjs.com/package/@fontsource/ibm-plex-serif) (Satori-compatible WOFF font asset).
+
+**Spec:** [`docs/superpowers/specs/2026-05-05-og-image-from-title-design.md`](../specs/2026-05-05-og-image-from-title-design.md). Branch: `og-image-from-title`.
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|------|--------|----------------|
+| `src/_config/og-image/rule.js` | new | `shouldGenerate(data) -> boolean` predicate |
+| `src/_config/og-image/cache.js` | new | `.cache/og/` manifest + cached PNG binaries; hash function with `RENDERER_VERSION` |
+| `src/_config/og-image/generator.js` | new | Pure `generate(title) -> Promise<Buffer>`; loads font + avatar once |
+| `src/_config/og-image/index.js` | new | `register(eleventyConfig)`; collection-capture closure + `eleventy.after` handler |
+| `eleventy.config.js` | modify | Import and call `register()` from the new module |
+| `src/posts/posts.11tydata.js` | modify | Add computed `ogImage` property |
+| `src/_includes/head.njk` | modify | Switch `og:image` block from `image` to `ogImage` |
+| `package.json` | modify | Add `satori`, `@fontsource/ibm-plex-serif`, `sharp` to `devDependencies` |
+| `_site/assets/img/og/*.png` | generated at build | Final output, written by after-build hook |
+| `.cache/og/manifest.json`, `.cache/og/*.png` | generated at build | Cache; gitignored via existing `.cache` rule |
+
+---
+
+## Task 1: Add dependencies
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install satori**
+
+Run from repo root:
+```bash
+npm install --save-dev satori
+```
+
+Expected: `package.json`'s `devDependencies` now includes `satori` (current version is 0.x — accept whatever npm resolves).
+
+- [ ] **Step 2: Install the font asset**
+
+```bash
+npm install --save-dev @fontsource/ibm-plex-serif
+```
+
+This package ships pre-built WOFF/TTF font files. We'll load the WOFF directly from `node_modules/@fontsource/ibm-plex-serif/files/ibm-plex-serif-latin-600-normal.woff` in the generator. (We can't reuse the existing `src/assets/fonts/ibm-plex-serif-600.woff2` because Satori does not support WOFF2.)
+
+- [ ] **Step 3: Pin sharp explicitly**
+
+```bash
+npm install --save-dev sharp
+```
+
+Sharp is already pulled in transitively by `@11ty/eleventy-img`. Adding it explicitly so our code doesn't depend on a transitive resolution that could disappear in a future eleventy-img release.
+
+- [ ] **Step 4: Verify the font file exists at the expected path**
+
+```bash
+ls node_modules/@fontsource/ibm-plex-serif/files/ibm-plex-serif-latin-600-normal.woff
+```
+
+Expected: the file exists and is non-zero. If it doesn't, the version of `@fontsource/ibm-plex-serif` you got may have a different file layout. Check `node_modules/@fontsource/ibm-plex-serif/files/` and update later tasks' paths to match. Do not proceed with a different filename guessed at random — read the actual contents of the `files/` directory.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "Add satori, sharp, and IBM Plex Serif font for OG image generation"
+```
+
+---
+
+## Task 2: Implement the rule predicate
+
+**Files:**
+- Create: `src/_config/og-image/rule.js`
+
+- [ ] **Step 1: Write the module**
+
+Create `src/_config/og-image/rule.js`:
+
+```js
+// Predicate: should this post receive a generated OG image?
+// A post matches if its tags include neither "notes" nor "til".
+// Used identically by the data cascade hook and the after-build hook
+// so they can never disagree on which posts qualify.
+export function shouldGenerate(data) {
+  const tags = Array.isArray(data?.tags) ? data.tags : [];
+  return !tags.includes("notes") && !tags.includes("til");
+}
+```
+
+- [ ] **Step 2: Manually verify the predicate**
+
+Run from repo root:
+```bash
+node --input-type=module -e '
+import("./src/_config/og-image/rule.js").then(({ shouldGenerate }) => {
+  console.log("regular post:", shouldGenerate({ tags: ["javascript"] }));      // true
+  console.log("note:",         shouldGenerate({ tags: ["notes"] }));           // false
+  console.log("til:",          shouldGenerate({ tags: ["til"] }));             // false
+  console.log("no tags:",      shouldGenerate({}));                            // true
+  console.log("mixed:",        shouldGenerate({ tags: ["notes", "x"] }));      // false
+});'
+```
+
+Expected output:
+```
+regular post: true
+note: false
+til: false
+no tags: true
+mixed: false
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/_config/og-image/rule.js
+git commit -m "Add OG image generation rule predicate"
+```
+
+---
+
+## Task 3: Implement the cache layer
+
+**Files:**
+- Create: `src/_config/og-image/cache.js`
+
+- [ ] **Step 1: Write the module**
+
+Create `src/_config/og-image/cache.js`:
+
+```js
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+// Bump when the visual spec or generator code changes in a way that
+// should invalidate every previously-cached PNG. The current value
+// is concatenated into the hash input so cached images become stale
+// automatically.
+const RENDERER_VERSION = "1";
+
+const CACHE_DIR = ".cache/og";
+const MANIFEST_PATH = path.join(CACHE_DIR, "manifest.json");
+
+export function hashTitle(title) {
+  return crypto
+    .createHash("sha1")
+    .update(`${RENDERER_VERSION}:${title}`)
+    .digest("hex")
+    .slice(0, 12);
+}
+
+async function ensureDir() {
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+}
+
+async function loadManifest() {
+  try {
+    const raw = await fs.readFile(MANIFEST_PATH, "utf8");
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err.code === "ENOENT") return {};
+    console.warn(`[og-image] manifest unreadable, starting fresh: ${err.message}`);
+    return {};
+  }
+}
+
+async function saveManifest(manifest) {
+  await ensureDir();
+  await fs.writeFile(MANIFEST_PATH, JSON.stringify(manifest, null, 2));
+}
+
+function cacheFileFor(slug, hash) {
+  return path.join(CACHE_DIR, `${slug}-${hash}.png`);
+}
+
+// Returns the cached PNG buffer if the slug+hash matches a stored entry,
+// else null. Errors (file missing, unreadable) are logged and treated
+// as cache miss.
+export async function get(slug, hash) {
+  const manifest = await loadManifest();
+  const entry = manifest[slug];
+  if (!entry || entry.hash !== hash) return null;
+  try {
+    return await fs.readFile(cacheFileFor(slug, hash));
+  } catch (err) {
+    console.warn(`[og-image] cache read failed for ${slug}: ${err.message}`);
+    return null;
+  }
+}
+
+// Writes the buffer to the cache file and updates the manifest.
+// Errors are logged but do not throw — the build proceeds with the
+// freshly-rendered buffer in memory.
+export async function put(slug, hash, buffer) {
+  await ensureDir();
+  const file = `${slug}-${hash}.png`;
+  try {
+    await fs.writeFile(path.join(CACHE_DIR, file), buffer);
+  } catch (err) {
+    console.warn(`[og-image] cache write failed for ${slug}: ${err.message}`);
+    return;
+  }
+  const manifest = await loadManifest();
+  manifest[slug] = { hash, file };
+  await saveManifest(manifest);
+}
+
+// Removes any cache file whose <slug>-<hash> isn't in activeKeys (a Set
+// of "<slug>-<hash>" strings) and prunes orphan manifest entries.
+export async function gc(activeKeys) {
+  let entries;
+  try {
+    entries = await fs.readdir(CACHE_DIR);
+  } catch (err) {
+    if (err.code === "ENOENT") return;
+    console.warn(`[og-image] gc readdir failed: ${err.message}`);
+    return;
+  }
+  for (const name of entries) {
+    if (!name.endsWith(".png")) continue;
+    const key = name.replace(/\.png$/, "");
+    if (!activeKeys.has(key)) {
+      try {
+        await fs.unlink(path.join(CACHE_DIR, name));
+      } catch (err) {
+        console.warn(`[og-image] gc unlink failed for ${name}: ${err.message}`);
+      }
+    }
+  }
+  const manifest = await loadManifest();
+  let dirty = false;
+  for (const [slug, entry] of Object.entries(manifest)) {
+    if (!activeKeys.has(`${slug}-${entry.hash}`)) {
+      delete manifest[slug];
+      dirty = true;
+    }
+  }
+  if (dirty) await saveManifest(manifest);
+}
+```
+
+- [ ] **Step 2: Manually verify hash determinism and round-trip**
+
+```bash
+node --input-type=module -e '
+import("./src/_config/og-image/cache.js").then(async (m) => {
+  const h1 = m.hashTitle("Hello world");
+  const h2 = m.hashTitle("Hello world");
+  const h3 = m.hashTitle("Hello world!");
+  console.log("same title same hash:", h1 === h2);          // true
+  console.log("different title different hash:", h1 !== h3); // true
+  await m.put("test-slug", h1, Buffer.from("not a png"));
+  const buf = await m.get("test-slug", h1);
+  console.log("round-trip:", buf?.toString());               // not a png
+  const miss = await m.get("test-slug", "deadbeef0000");
+  console.log("miss:", miss);                                // null
+  await m.gc(new Set());
+  const after = await m.get("test-slug", h1);
+  console.log("after gc:", after);                           // null
+});'
+```
+
+Expected output:
+```
+same title same hash: true
+different title different hash: true
+round-trip: not a png
+miss: null
+after gc: null
+```
+
+- [ ] **Step 3: Confirm `.cache` is gitignored**
+
+```bash
+grep -E "^\.cache" .gitignore
+```
+
+Expected: outputs `.cache`. (It already is — this is just a sanity check before committing.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/_config/og-image/cache.js
+git commit -m "Add OG image cache with title-hash invalidation"
+```
+
+---
+
+## Task 4: Implement the renderer
+
+**Files:**
+- Create: `src/_config/og-image/generator.js`
+
+- [ ] **Step 1: Write the module**
+
+Create `src/_config/og-image/generator.js`:
+
+```js
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import satori from "satori";
+import sharp from "sharp";
+
+const require = createRequire(import.meta.url);
+
+// Load font and avatar once per process. Both are small (~100KB each)
+// and reused for every render.
+const FONT_PATH = require.resolve(
+  "@fontsource/ibm-plex-serif/files/ibm-plex-serif-latin-600-normal.woff",
+);
+const FONT_DATA = fs.readFileSync(FONT_PATH);
+
+const AVATAR_PATH = path.resolve("src/assets/img/about-bob.jpg");
+const AVATAR_BUFFER = fs.readFileSync(AVATAR_PATH);
+const AVATAR_DATA_URI = `data:image/jpeg;base64,${AVATAR_BUFFER.toString("base64")}`;
+
+// Deterministic font-size ramp keyed to title length. Same title always
+// renders at the same size.
+function pickFontSize(title) {
+  if (title.length <= 60) return 88;
+  if (title.length <= 90) return 72;
+  return 60;
+}
+
+function buildTree(title) {
+  return {
+    type: "div",
+    props: {
+      style: {
+        width: "1200px",
+        height: "630px",
+        backgroundColor: "#353d4d",
+        display: "flex",
+        position: "relative",
+        padding: "80px",
+        boxSizing: "border-box",
+      },
+      children: [
+        {
+          type: "div",
+          props: {
+            style: {
+              color: "#ffffff",
+              fontFamily: "IBM Plex Serif",
+              fontWeight: 600,
+              fontSize: `${pickFontSize(title)}px`,
+              lineHeight: 1.15,
+              letterSpacing: "-0.01em",
+              maxWidth: "880px",
+              display: "flex",
+            },
+            children: title,
+          },
+        },
+        {
+          type: "img",
+          props: {
+            src: AVATAR_DATA_URI,
+            width: 180,
+            height: 180,
+            style: {
+              position: "absolute",
+              bottom: "60px",
+              right: "60px",
+              borderRadius: "9999px",
+              border: "4px solid #c7e2f6",
+            },
+          },
+        },
+      ],
+    },
+  };
+}
+
+// Renders the OG image for `title` and returns a PNG Buffer.
+// Throws on font/image load failure, malformed input, or sharp error.
+// Callers should catch and log a warning per the spec's error policy.
+export async function generate(title) {
+  const svg = await satori(buildTree(title), {
+    width: 1200,
+    height: 630,
+    fonts: [
+      {
+        name: "IBM Plex Serif",
+        data: FONT_DATA,
+        weight: 600,
+        style: "normal",
+      },
+    ],
+  });
+  return await sharp(Buffer.from(svg)).png().toBuffer();
+}
+```
+
+- [ ] **Step 2: Render a sample image and eyeball it**
+
+Run from repo root:
+```bash
+node --input-type=module -e '
+import("./src/_config/og-image/generator.js").then(async ({ generate }) => {
+  const fs = await import("node:fs/promises");
+  const buf = await generate("Auto-generated OG images from post titles");
+  await fs.writeFile("/tmp/og-sample.png", buf);
+  console.log("wrote", buf.length, "bytes");
+});'
+```
+
+Open `/tmp/og-sample.png` and confirm:
+- 1200×630 PNG
+- Dark background (#353d4d)
+- Title in white serif on the left, fits within the canvas
+- Round Bob avatar in the bottom-right with a light border
+
+- [ ] **Step 3: Try the long-title branch**
+
+```bash
+node --input-type=module -e '
+import("./src/_config/og-image/generator.js").then(async ({ generate }) => {
+  const fs = await import("node:fs/promises");
+  const long = "A very long title that should trigger the smaller font size and wrap onto multiple lines without colliding with the avatar in the corner";
+  const buf = await generate(long);
+  await fs.writeFile("/tmp/og-sample-long.png", buf);
+  console.log("wrote", buf.length, "bytes");
+});'
+```
+
+Open `/tmp/og-sample-long.png`. Confirm the title wraps to multiple lines, font is smaller (60px tier), and the avatar isn't crashed into.
+
+- [ ] **Step 4: Clean up samples and commit**
+
+```bash
+rm /tmp/og-sample.png /tmp/og-sample-long.png
+git add src/_config/og-image/generator.js
+git commit -m "Add Satori-based OG image renderer"
+```
+
+---
+
+## Task 5: Implement the orchestrator
+
+**Files:**
+- Create: `src/_config/og-image/index.js`
+
+- [ ] **Step 1: Write the module**
+
+Create `src/_config/og-image/index.js`:
+
+```js
+import fs from "node:fs/promises";
+import path from "node:path";
+import { shouldGenerate } from "./rule.js";
+import { generate } from "./generator.js";
+import * as cache from "./cache.js";
+
+// Captured during the data cascade (when we have access to post data),
+// consumed during the after-build hook (when the data cascade is gone).
+// Reset on each build via "eleventy.before".
+let queue = [];
+
+export default function register(eleventyConfig) {
+  eleventyConfig.on("eleventy.before", () => {
+    queue = [];
+  });
+
+  // Capture matching posts during the data cascade. Returning [] means
+  // this collection is empty in templates — we only use the callback
+  // for its side effect of populating `queue`.
+  eleventyConfig.addCollection("ogImageQueue", (api) => {
+    queue = api
+      .getFilteredByGlob("./src/posts/**/*.md")
+      .filter((p) => shouldGenerate(p.data))
+      .map((p) => ({ slug: p.fileSlug, title: p.data.title }));
+    return [];
+  });
+
+  eleventyConfig.on("eleventy.after", async ({ dir }) => {
+    const outDir = path.join(dir.output, "assets/img/og");
+    await fs.mkdir(outDir, { recursive: true });
+
+    const activeKeys = new Set();
+
+    for (const { slug, title } of queue) {
+      const hash = cache.hashTitle(title);
+      activeKeys.add(`${slug}-${hash}`);
+
+      let buf = await cache.get(slug, hash);
+      if (!buf) {
+        try {
+          buf = await generate(title);
+          await cache.put(slug, hash, buf);
+        } catch (err) {
+          console.warn(
+            `[og-image] generation failed for slug=${slug}: ${err.message}`,
+          );
+          continue;
+        }
+      }
+
+      try {
+        await fs.writeFile(path.join(outDir, `${slug}.png`), buf);
+      } catch (err) {
+        console.warn(
+          `[og-image] write to _site failed for slug=${slug}: ${err.message}`,
+        );
+      }
+    }
+
+    await cache.gc(activeKeys);
+  });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/_config/og-image/index.js
+git commit -m "Add OG image plugin orchestrator"
+```
+
+---
+
+## Task 6: Wire the plugin into Eleventy
+
+**Files:**
+- Modify: `eleventy.config.js`
+
+- [ ] **Step 1: Add the import and registration**
+
+In `eleventy.config.js`, add a new import alongside the existing utils import (currently around line 5):
+
+```js
+import addrssid from "./src/_config/utils/addrssid.js";
+import registerOgImage from "./src/_config/og-image/index.js";
+```
+
+Inside the default-export function, add the registration call. A good location is right after the existing `eleventyConfig.addPlugin(filters)` line (around line 65), grouped with the other plugin/registration code:
+
+```js
+  // Add local filters
+  eleventyConfig.addPlugin(filters);
+
+  // Register OG image generation
+  registerOgImage(eleventyConfig);
+```
+
+- [ ] **Step 2: Run a build and confirm files are generated**
+
+```bash
+npm run build
+```
+
+Expected: build completes, no errors. Then:
+
+```bash
+ls _site/assets/img/og/ | wc -l
+```
+
+Expected: 71 (or close — the count from spec is 71 non-notes/non-TIL posts; the actual number depends on whether new posts have been added since spec was written).
+
+```bash
+ls _site/assets/img/og/ | head -5
+```
+
+Expected: filenames like `<post-slug>.png`.
+
+- [ ] **Step 3: Confirm the cache populated**
+
+```bash
+ls .cache/og/ | head -5
+cat .cache/og/manifest.json | head -20
+```
+
+Expected: PNG files named `<slug>-<hash>.png`, and a manifest mapping slugs to hash/file entries.
+
+- [ ] **Step 4: Open one PNG and eyeball it**
+
+Open any file from `_site/assets/img/og/` (e.g., `_site/assets/img/og/3-years-of-the-11ty-bundle.png` if that post is present). Confirm the title is correct, layout is correct, avatar in bottom-right.
+
+- [ ] **Step 5: Run the build again — it should be a cache-hit pass**
+
+```bash
+time npm run build
+```
+
+The eleventy build itself should complete in roughly the same time as before this plan (within ~1s of normal) — Satori shouldn't run again. You can verify Satori isn't running by adding a `console.log("rendering", title)` line temporarily in `generator.js` Step 1 of Task 4 (and removing it after); on the second run no logs should appear. (Optional debugging step; skip if confident.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add eleventy.config.js
+git commit -m "Register OG image plugin in Eleventy config"
+```
+
+---
+
+## Task 7: Compute `ogImage` in the post data file
+
+**Files:**
+- Modify: `src/posts/posts.11tydata.js`
+
+- [ ] **Step 1: Add the computed property**
+
+Replace the contents of `src/posts/posts.11tydata.js` with:
+
+```js
+export default {
+  eleventyComputed: {
+    layout: "postgrid.njk",
+    whichgrid: "central",
+    permalink: (data) => `blog/${data.page.fileSlug}/`,
+    imageDir: "src/assets/img/",
+    image: (data) => {
+      if (data.image && data.image.source) {
+        return data.image;
+      }
+      if (data.tags?.includes("notes")) {
+        return { source: "notes-og-image.jpg" };
+      }
+      if (data.tags?.includes("til")) {
+        return { source: "til-og-image.jpg" };
+      }
+    },
+    // OG image (social-share card) is independent of `image` (in-body hero).
+    // Notes and TILs use their dedicated default cards; every other post
+    // uses a build-time-generated card at /assets/img/og/<slug>.png.
+    ogImage: (data) => {
+      if (data.tags?.includes("notes")) {
+        return {
+          source: "notes-og-image.jpg",
+          alt: "Bob Monsour's blog — note",
+        };
+      }
+      if (data.tags?.includes("til")) {
+        return {
+          source: "til-og-image.jpg",
+          alt: "Bob Monsour's blog — TIL",
+        };
+      }
+      return {
+        source: `og/${data.page.fileSlug}.png`,
+        alt: data.title,
+      };
+    },
+    showImage: true,
+    keywords: "retired, web development, blog, eleventy, tennis",
+  },
+};
+```
+
+Note the change to the `image` computed function: I added `?.` to the `data.tags` checks because under the hood `data.tags` may be undefined for posts that don't declare any tags. The original code used `data.tags.includes(...)` which would throw on such posts. Behavior is unchanged for posts that have tags. (If review prefers to keep the data file's existing behavior and only add `ogImage`, leave `data.tags.includes(...)` and trust that all posts declare tags — verify by spot-checking the front matter of a few posts.)
+
+- [ ] **Step 2: Build and inspect a rendered post for the new data**
+
+```bash
+npm run build
+```
+
+Then check that some non-notes/non-TIL post's HTML still has the old `og:image` referencing the original `image.source` path (because head.njk hasn't been switched yet — that's Task 8). The data file change alone should not yet affect the rendered output:
+
+```bash
+grep -m1 "og:image" _site/blog/3-years-of-the-11ty-bundle/index.html
+```
+
+Expected: the existing `og:image` line is unchanged from before this task. (We're confirming we didn't accidentally break the rendering path.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/posts/posts.11tydata.js
+git commit -m "Compute ogImage data property for posts"
+```
+
+---
+
+## Task 8: Switch `head.njk` to consume `ogImage`
+
+**Files:**
+- Modify: `src/_includes/head.njk:74-80`
+
+- [ ] **Step 1: Update the OG image block**
+
+In `src/_includes/head.njk`, replace the existing block:
+
+```njk
+  {% if image and image.source %}
+  <meta property="og:image" content="{{ site.url }}/assets/img/{{ image.source }}">
+  <meta property="og:image:alt" content="{{ image.alt }}">
+  {% else %}
+  <meta property="og:image" content="{{ site.url }}/assets/img/fallback-og-image.png">
+  <meta property="og:image:alt" content="Bob Monsour's personal website">
+  {% endif %}
+```
+
+with:
+
+```njk
+  {% if ogImage and ogImage.source %}
+  <meta property="og:image" content="{{ site.url }}/assets/img/{{ ogImage.source }}">
+  <meta property="og:image:alt" content="{{ ogImage.alt }}">
+  {% else %}
+  <meta property="og:image" content="{{ site.url }}/assets/img/fallback-og-image.png">
+  <meta property="og:image:alt" content="Bob Monsour's personal website">
+  {% endif %}
+```
+
+The only changes are `image` → `ogImage` (twice in the conditional and meta-tag references). Non-post pages (about, books, projects, etc.) don't define `ogImage`, so they fall through to the `fallback-og-image.png` else-branch as before.
+
+- [ ] **Step 2: Build and verify the OG meta points at the generated path**
+
+```bash
+npm run build
+grep -m1 "og:image" _site/blog/3-years-of-the-11ty-bundle/index.html
+```
+
+Expected:
+```
+<meta property="og:image" content="https://www.bobmonsour.com/assets/img/og/3-years-of-the-11ty-bundle.png">
+```
+
+(Substitute any non-notes/non-TIL post slug present in the build.)
+
+- [ ] **Step 3: Verify a notes-tagged post still uses the notes default**
+
+Pick a notes-tagged post:
+```bash
+grep -lE "^\s*-\s+notes\s*$" src/posts/**/*.md | head -1
+```
+
+Take its slug (the filename without `.md`) and check the rendered output:
+```bash
+grep -m1 "og:image" _site/blog/<slug>/index.html
+```
+
+Expected:
+```
+<meta property="og:image" content="https://www.bobmonsour.com/assets/img/notes-og-image.jpg">
+```
+
+- [ ] **Step 4: Verify a non-post page falls back**
+
+```bash
+grep -m1 "og:image" _site/about/index.html
+```
+
+Expected:
+```
+<meta property="og:image" content="https://www.bobmonsour.com/assets/img/fallback-og-image.png">
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/_includes/head.njk
+git commit -m "Switch og:image meta tag to read ogImage data property"
+```
+
+---
+
+## Task 9: End-to-end verification per spec checklist
+
+This task runs the full spec verification checklist. Each step is an observation, not a code change. No commit at the end unless something needs fixing.
+
+- [ ] **Step 1: Spec check item 1 — fresh post end-to-end**
+
+Create a temporary test post:
+
+```bash
+mkdir -p src/posts/2026 && cat > src/posts/2026/_og-image-test-post.md <<'EOF'
+---
+title: A test post for OG image generation
+description: Throwaway post for verifying OG image build behavior.
+date: 2026-05-05
+tags:
+  - testing
+draft: true
+---
+
+This is a throwaway post.
+EOF
+```
+
+Note: `draft: true` keeps it out of production builds (per the existing drafts preprocessor in `eleventy.config.js`), but the dev server/local build will still process it. Run a non-build (dev-mode equivalent) build:
+
+```bash
+ELEVENTY_RUN_MODE=serve npx @11ty/eleventy
+```
+
+Then check:
+```bash
+ls _site/assets/img/og/_og-image-test-post.png
+```
+
+Expected: file exists. Open it and verify the title text in the image matches "A test post for OG image generation."
+
+- [ ] **Step 2: Spec check item 2 — meta tag points at the generated path**
+
+```bash
+grep -m1 "og:image" _site/blog/_og-image-test-post/index.html
+```
+
+Expected: `content="https://www.bobmonsour.com/assets/img/og/_og-image-test-post.png"`.
+
+- [ ] **Step 3: Spec check item 3 — title change triggers regen**
+
+Edit the test post's `title` to something different (e.g., "A renamed test post"). Re-run the build. Open the PNG; the title text should be the new one. Inspect `.cache/og/manifest.json` and confirm the entry for `_og-image-test-post` now has a different `hash` value than before.
+
+- [ ] **Step 4: Spec check item 4 — unchanged build is a cache hit**
+
+Run the build again with no changes:
+```bash
+ELEVENTY_RUN_MODE=serve npx @11ty/eleventy
+```
+
+`_site/assets/img/og/_og-image-test-post.png` should be byte-identical to the previous build (compare with `cmp` or check that the manifest hash didn't change).
+
+- [ ] **Step 5: Spec check item 5 — short and long titles**
+
+Already covered in Task 4 Step 3 (long-title eyeball). If you want a fresh check after end-to-end integration, edit the test post's title to a long string (~100 chars) and rebuild; open the PNG.
+
+- [ ] **Step 6: Spec check item 6 — notes post unaffected**
+
+Pick a notes-tagged post, e.g. `<slug>` from Task 8 Step 3.
+
+```bash
+ls _site/assets/img/og/<slug>.png 2>/dev/null && echo "FAIL: should not exist" || echo "OK: not generated"
+grep -m1 "og:image" _site/blog/<slug>/index.html
+```
+
+Expected: "OK: not generated" and the meta tag points at `notes-og-image.jpg`.
+
+- [ ] **Step 7: Spec check item 7 — post with explicit `image:` has both hero and generated OG**
+
+Pick any existing post with an `image:` front matter block (most posts have one). Inspect the rendered HTML:
+
+```bash
+grep -m1 "og:image" _site/blog/<that-post-slug>/index.html
+grep -m1 "<img src" _site/blog/<that-post-slug>/index.html
+```
+
+Expected:
+- `og:image` content points at `/assets/img/og/<that-post-slug>.png` (the generated card).
+- The first `<img>` tag in the rendered article (from `showimage.njk`) still references the front-matter `image.source` (the hero).
+
+- [ ] **Step 8: Spec check item 8 — manifest size**
+
+```bash
+node --input-type=module -e '
+import("node:fs/promises").then(async (fs) => {
+  const m = JSON.parse(await fs.readFile(".cache/og/manifest.json", "utf8"));
+  console.log("manifest entries:", Object.keys(m).length);
+});'
+```
+
+Expected: ~71 (matching the count of non-notes/non-TIL posts at design time, plus 1 for the test post if it's still around).
+
+- [ ] **Step 9: Clean up the test post**
+
+```bash
+rm src/posts/2026/_og-image-test-post.md
+ELEVENTY_RUN_MODE=serve npx @11ty/eleventy
+```
+
+After the rebuild, the manifest should have removed `_og-image-test-post` (gc step), and `_site/assets/img/og/_og-image-test-post.png` should not exist:
+
+```bash
+ls _site/assets/img/og/_og-image-test-post.png 2>/dev/null && echo "FAIL: leftover" || echo "OK: cleaned"
+```
+
+Expected: "OK: cleaned".
+
+- [ ] **Step 10: Final production build sanity check**
+
+```bash
+npm run build
+```
+
+Expected: completes without errors. The pagefind postbuild step runs as usual.
+
+```bash
+ls _site/assets/img/og/ | wc -l
+```
+
+Expected: 71 (the production count, minus draft posts).
+
+- [ ] **Step 11: No commit needed**
+
+This task observes only; nothing is staged.
+
+---
+
+## Self-review checklist (post-write)
+
+- **Spec coverage:**
+  - Scope (Task 7 rule + Task 5 queue) ✓
+  - Visual spec (Task 4 generator) ✓
+  - Architecture: data cascade + after-build hook (Tasks 5, 7) ✓
+  - Components: rule.js (Task 2), cache.js (Task 3), generator.js (Task 4), index.js (Task 5) ✓
+  - posts.11tydata.js change (Task 7) ✓
+  - head.njk change (Task 8) ✓
+  - Caching/regen with hash + RENDERER_VERSION (Task 3) ✓
+  - Error handling: warn-and-continue (Tasks 3, 5) ✓
+  - Dependencies: satori, sharp, @fontsource/ibm-plex-serif (Task 1) ✓
+  - Verification per spec items 1–8 (Task 9) ✓
+- **Placeholders:** none.
+- **Type/name consistency:** `shouldGenerate(data)` (Task 2) used consistently in Task 5; `hashTitle(title)`, `get(slug, hash)`, `put(slug, hash, buffer)`, `gc(activeKeys)` (Task 3) match Task 5's call sites; `generate(title)` (Task 4) matches Task 5; `register(eleventyConfig)` (Task 5) matches Task 6's import name `registerOgImage`.

--- a/docs/superpowers/specs/2026-05-05-og-image-from-title-design.md
+++ b/docs/superpowers/specs/2026-05-05-og-image-from-title-design.md
@@ -1,0 +1,145 @@
+# Auto-generated OG images from post titles
+
+**Status:** design
+**Date:** 2026-05-05
+**Branch:** `og-image-from-title`
+**Source idea:** [`docs/og-image-based-on-title.md`](../../og-image-based-on-title.md)
+
+## Goal
+
+Generate a per-post Open Graph image at build time for blog posts that don't supply their own, so social shares display the post title alongside a recognizable image of Bob, in the site's visual style. Generation runs during every build (local and deploy), but is cached so unchanged posts don't re-render.
+
+## Scope
+
+A generated OG image is produced for any post in `collections.posts` where:
+
+- The post does **not** have an `image.source` in its front matter, and
+- The post is **not** tagged `notes` or `til`.
+
+Posts with explicit `image.source` keep using that image for OG meta. Notes and TILs continue to use `notes-og-image.jpg` / `til-og-image.jpg`. Non-post pages (about, books, projects, etc.) continue to use `fallback-og-image.png`.
+
+In practice this affects only future posts: a check at design time confirmed every existing non-notes/non-TIL post already has `image.source`.
+
+## Visual specification
+
+- **Canvas:** 1200×630 PNG.
+- **Background:** solid `#353d4d` (the site's `--color-dark`).
+- **Title:** IBM Plex Serif weight 600, color `#ffffff`, left-aligned, ~80px left/top padding, max width ~880px so it never collides with the avatar. Font size is chosen by a deterministic ramp keyed to title length (`<=60` chars → 88px, `<=90` → 72px, otherwise 60px) so the same title always renders the same size. Satori's flexbox layout handles line wrapping at the chosen size.
+- **Avatar:** `src/assets/img/about-bob.jpg` (200×200 source) rendered as a 180px circle in the bottom-right corner with ~60px margin from the right and bottom edges. A 4px `#c7e2f6` border (the site's `--color-light`) gives the circle a subtle ring against the dark background.
+- **No site name, no tagline, no decorative elements.**
+
+## Architecture
+
+A self-contained module at `src/_config/og-image/` is loaded from `eleventy.config.js`. It does two things:
+
+1. **Data cascade hook.** Extends the existing `eleventyComputed.image` logic in `src/posts/posts.11tydata.js` to also compute a new `ogImage` property. `ogImage` is the only field `head.njk` consults for `og:image` meta. `image` continues to mean "in-body hero" exclusively.
+2. **After-build hook.** Iterates `collections.posts`, and for each post matching the rule, resolves the PNG (cache hit or fresh render via Satori + sharp) and writes it to `_site/assets/img/og/<slug>.png`.
+
+The path that the OG meta tag references and the path the file is written to are the same. The data cascade sets the path; the after-build hook makes the file exist.
+
+### Why `ogImage` vs reusing `image`
+
+Today, `image.source` drives both the OG meta tag (`head.njk`) and the in-body hero (`showimage.njk`). If the generated OG image were assigned to `image.source`, every matching post would display the generated OG image as a hero above its content — redundant with the `<h1>` already rendered by `postgrid.njk`. Splitting into two fields decouples the concerns:
+
+- `image` = in-body hero (front-matter, opt-in by author).
+- `ogImage` = OG meta (computed, with cascade).
+
+For posts that already set `image`, `ogImage` defaults to that same value, so existing OG behavior is unchanged.
+
+## Components
+
+```
+src/_config/og-image/
+  index.js              public API: register(eleventyConfig)
+  generator.js          pure: (title) -> Promise<Buffer>  (Satori + sharp)
+  cache.js              .cache/og/manifest.json + .cache/og/<slug>-<hash>.png
+  rule.js               shouldGenerate(postData) -> boolean
+```
+
+- **`generator.js`** loads `src/assets/img/about-bob.jpg` and `src/assets/fonts/ibm-plex-serif-600.woff2` once per build, builds the Satori VDOM tree per the visual spec above, runs `satori(...)` to get an SVG string, runs `sharp(svg).png().toBuffer()`, returns the buffer.
+- **`cache.js`** owns `.cache/og/`. Methods:
+  - `get(slug, titleHash) -> Buffer | null` — reads `.cache/og/<slug>-<hash>.png` if it exists.
+  - `put(slug, titleHash, buffer) -> void` — writes the PNG and updates `manifest.json`.
+  - `gc(activeEntries)` — at end of build, removes any cache file whose `<slug>-<hash>` doesn't match the current manifest.
+  - `titleHash = sha1(title).slice(0, 12)`.
+- **`rule.js`** centralizes the predicate: a post matches if it has no `image.source` AND its tags include neither `notes` nor `til`. Used identically by the data hook and the after-build hook so they can never disagree.
+- **`index.js`** wires both hooks. Exports a single function called from `eleventy.config.js`.
+
+`src/posts/posts.11tydata.js` is updated to compute `ogImage` via the cascade:
+
+```
+ogImage =
+    image                                                 (if image.source set)
+ || (tags.includes("notes") ? { source: "notes-og-image.jpg", alt: "..." } : null)
+ || (tags.includes("til")   ? { source: "til-og-image.jpg",   alt: "..." } : null)
+ || { source: "og/<slug>.png", alt: title }               (matching post)
+```
+
+`src/_includes/head.njk` is updated so the `og:image` block reads `ogImage` instead of `image`: the conditional becomes `{% if ogImage and ogImage.source %}`, and the two meta tags inside reference `ogImage.source` and `ogImage.alt`. The `fallback-og-image.png` else-branch stays for non-post pages.
+
+`showimage.njk` is **not** changed.
+
+## Data flow
+
+```
+build start
+  -> posts.11tydata.js eleventyComputed.ogImage runs per post
+     -> matching posts: ogImage = { source: "og/<slug>.png", alt: title }
+  -> templates render
+     -> head.njk emits <meta property="og:image" content="<site.url>/assets/img/og/<slug>.png">
+  -> eleventy.after fires
+     -> for each post in collections.posts where rule.shouldGenerate(data):
+          hash = sha1(title).slice(0,12)
+          buf  = cache.get(slug, hash) ?? (generator(title) -> cache.put(slug, hash, .))
+          fs.writeFile(_site/assets/img/og/<slug>.png, buf)
+     -> cache.gc(activeEntries)
+  -> postbuild (pagefind) runs
+  -> wrangler deploy ships _site/
+```
+
+## Caching and regeneration
+
+- Cache lives at `.cache/og/`. Already gitignored via the existing `.cache` line.
+- `manifest.json` shape: `{ "<slug>": { "hash": "<sha1-12>", "file": "<slug>-<hash>.png" } }`.
+- Cache hit: file copied to `_site/`. Cache miss: render, persist, copy.
+- Title change → hash mismatch → render. No other inputs feed the hash; if the visual spec or rendering code ever changes in a way that should invalidate every cached image, bump a `RENDERER_VERSION` constant defined in `cache.js` and concatenated into the hash input.
+- PNGs are not committed. First build on a fresh clone regenerates everything (~150ms × N matching posts; today, 0; in steady state, the per-build delta is "however many posts you wrote since last build").
+- Bob deploys via `npm run build && wrangler deploy` from his local machine, so the cache persists naturally across deploys.
+
+## Error handling
+
+- `generator()` throws (font load, image load, Satori panic) → log a warning naming the slug, do not write the PNG, do not update the manifest. The OG meta tag still references the missing path; the social crawler falls through to whatever it does for 404 images. The build does not fail.
+- Cache read/write errors → log warning, treat as cache miss / no-op respectively.
+- No retry, no fallback rendering. Failures are visible in build logs and rare.
+
+## Dependencies
+
+Add to `devDependencies`:
+
+- `satori` — JSX/HTML-to-SVG renderer.
+
+`sharp` is already pulled in transitively by `@11ty/eleventy-img` and is used directly to convert Satori's SVG output to PNG.
+
+No native deps beyond what's already installed.
+
+## Verification (manual)
+
+No test framework is added. Verification is by eyeball + filesystem checks:
+
+1. Create a test post in `src/posts/2026/` without an `image:` front-matter field. Run `npm run build`. Confirm `_site/assets/img/og/<slug>.png` exists and looks right.
+2. View the rendered post HTML; confirm the `<meta property="og:image">` tag points at `/assets/img/og/<slug>.png`.
+3. Change the test post's `title`, rebuild. Confirm the PNG changes (mtime updates and the rendered title in the image is the new one).
+4. Rebuild without changes. Confirm the cache hit path runs (PNG mtime unchanged).
+5. Visual: render with a short title (~20 chars) and a long title (~100 chars); confirm wrapping and font-size step-down both look reasonable.
+6. Confirm a notes-tagged post still uses `notes-og-image.jpg` for OG meta and produces no entry under `_site/assets/img/og/`.
+7. Confirm an existing post with explicit `image:` still renders its hero in the body and uses the same image for OG meta.
+8. Inspect `.cache/og/manifest.json` after a build; confirm one entry per matching post.
+
+## Out of scope
+
+- Regenerating OG images for existing posts that already have `image.source` set. (Explicit author choice wins.)
+- Title-from-image generation for notes or TILs. (They keep their dedicated defaults.)
+- Light-mode variants. (Single dark image for all consumers.)
+- Per-post overrides of the visual template (font, colors, avatar). (Add later if needed.)
+- A test framework. (Manual verification only, consistent with the rest of the repo.)
+- Pruning historical artifacts. (Generated images are not committed; nothing to prune.)

--- a/docs/superpowers/specs/2026-05-05-og-image-from-title-design.md
+++ b/docs/superpowers/specs/2026-05-05-og-image-from-title-design.md
@@ -11,14 +11,11 @@ Generate a per-post Open Graph image at build time for blog posts that don't sup
 
 ## Scope
 
-A generated OG image is produced for any post in `collections.posts` where:
+A generated OG image is produced for **every** post in `collections.posts` that is **not** tagged `notes` or `til`. The post's `image` front-matter (if any) is irrelevant to OG image generation — it controls only the in-body hero.
 
-- The post does **not** have an `image.source` in its front matter, and
-- The post is **not** tagged `notes` or `til`.
+Notes and TILs continue to use `notes-og-image.jpg` / `til-og-image.jpg` for OG meta. Non-post pages (about, books, projects, etc.) continue to use `fallback-og-image.png`.
 
-Posts with explicit `image.source` keep using that image for OG meta. Notes and TILs continue to use `notes-og-image.jpg` / `til-og-image.jpg`. Non-post pages (about, books, projects, etc.) continue to use `fallback-og-image.png`.
-
-In practice this affects only future posts: a check at design time confirmed every existing non-notes/non-TIL post already has `image.source`.
+This applies retroactively to existing posts. At design time, 71 of 109 posts qualify; the first build on a fresh clone renders all 71 (~10s of one-time work). Subsequent builds skip them via cache.
 
 ## Visual specification
 
@@ -39,12 +36,12 @@ The path that the OG meta tag references and the path the file is written to are
 
 ### Why `ogImage` vs reusing `image`
 
-Today, `image.source` drives both the OG meta tag (`head.njk`) and the in-body hero (`showimage.njk`). If the generated OG image were assigned to `image.source`, every matching post would display the generated OG image as a hero above its content — redundant with the `<h1>` already rendered by `postgrid.njk`. Splitting into two fields decouples the concerns:
+Today, `image.source` drives both the OG meta tag (`head.njk`) and the in-body hero (`showimage.njk`). Conflating the two prevents the design Bob wants: keep specifying a hero per post (in body) while having social shares always show the generated card. Splitting into two independent fields makes the concerns explicit:
 
-- `image` = in-body hero (front-matter, opt-in by author).
-- `ogImage` = OG meta (computed, with cascade).
+- `image` = in-body hero. Author-controlled via front matter; rendered by `showimage.njk`. Unchanged.
+- `ogImage` = OG meta image. Computed by the data cascade; consumed only by `head.njk`. New.
 
-For posts that already set `image`, `ogImage` defaults to that same value, so existing OG behavior is unchanged.
+The two fields never reference the same value. A post with a hero `image` still gets a generated `ogImage`.
 
 ## Components
 
@@ -62,18 +59,19 @@ src/_config/og-image/
   - `put(slug, titleHash, buffer) -> void` — writes the PNG and updates `manifest.json`.
   - `gc(activeEntries)` — at end of build, removes any cache file whose `<slug>-<hash>` doesn't match the current manifest.
   - `titleHash = sha1(title).slice(0, 12)`.
-- **`rule.js`** centralizes the predicate: a post matches if it has no `image.source` AND its tags include neither `notes` nor `til`. Used identically by the data hook and the after-build hook so they can never disagree.
+- **`rule.js`** centralizes the predicate: a post matches if its tags include neither `notes` nor `til`. Used identically by the data hook and the after-build hook so they can never disagree.
 - **`index.js`** wires both hooks. Exports a single function called from `eleventy.config.js`.
 
 `src/posts/posts.11tydata.js` is updated to compute `ogImage` via the cascade:
 
 ```
 ogImage =
-    image                                                 (if image.source set)
- || (tags.includes("notes") ? { source: "notes-og-image.jpg", alt: "..." } : null)
+    (tags.includes("notes") ? { source: "notes-og-image.jpg", alt: "..." } : null)
  || (tags.includes("til")   ? { source: "til-og-image.jpg",   alt: "..." } : null)
- || { source: "og/<slug>.png", alt: title }               (matching post)
+ || { source: "og/<slug>.png", alt: title }               (every other post)
 ```
+
+`ogImage` is computed independently of `image`. The existing `image` computation (which still drives `showimage.njk`) is left untouched.
 
 `src/_includes/head.njk` is updated so the `og:image` block reads `ogImage` instead of `image`: the conditional becomes `{% if ogImage and ogImage.source %}`, and the two meta tags inside reference `ogImage.source` and `ogImage.alt`. The `fallback-og-image.png` else-branch stays for non-post pages.
 
@@ -103,7 +101,7 @@ build start
 - `manifest.json` shape: `{ "<slug>": { "hash": "<sha1-12>", "file": "<slug>-<hash>.png" } }`.
 - Cache hit: file copied to `_site/`. Cache miss: render, persist, copy.
 - Title change → hash mismatch → render. No other inputs feed the hash; if the visual spec or rendering code ever changes in a way that should invalidate every cached image, bump a `RENDERER_VERSION` constant defined in `cache.js` and concatenated into the hash input.
-- PNGs are not committed. First build on a fresh clone regenerates everything (~150ms × N matching posts; today, 0; in steady state, the per-build delta is "however many posts you wrote since last build").
+- PNGs are not committed. First build on a fresh clone regenerates everything (~150ms × N matching posts; today, 71 posts, ~10s one-time). In steady state, the per-build delta is "however many posts you wrote or retitled since last build."
 - Bob deploys via `npm run build && wrangler deploy` from his local machine, so the cache persists naturally across deploys.
 
 ## Error handling
@@ -132,12 +130,11 @@ No test framework is added. Verification is by eyeball + filesystem checks:
 4. Rebuild without changes. Confirm the cache hit path runs (PNG mtime unchanged).
 5. Visual: render with a short title (~20 chars) and a long title (~100 chars); confirm wrapping and font-size step-down both look reasonable.
 6. Confirm a notes-tagged post still uses `notes-og-image.jpg` for OG meta and produces no entry under `_site/assets/img/og/`.
-7. Confirm an existing post with explicit `image:` still renders its hero in the body and uses the same image for OG meta.
-8. Inspect `.cache/og/manifest.json` after a build; confirm one entry per matching post.
+7. Confirm an existing post with explicit `image:` (a) still renders that hero in the body via `showimage.njk` AND (b) has its `og:image` meta tag pointing at the newly generated `og/<slug>.png` (not the hero).
+8. Inspect `.cache/og/manifest.json` after a build; confirm one entry per non-notes/non-TIL post (~71 entries).
 
 ## Out of scope
 
-- Regenerating OG images for existing posts that already have `image.source` set. (Explicit author choice wins.)
 - Title-from-image generation for notes or TILs. (They keep their dedicated defaults.)
 - Light-mode variants. (Single dark image for all consumers.)
 - Per-post overrides of the visual template (font, colors, avatar). (Add later if needed.)

--- a/docs/superpowers/specs/2026-05-05-og-image-from-title-design.md
+++ b/docs/superpowers/specs/2026-05-05-og-image-from-title-design.md
@@ -53,7 +53,7 @@ src/_config/og-image/
   rule.js               shouldGenerate(postData) -> boolean
 ```
 
-- **`generator.js`** loads `src/assets/img/about-bob.jpg` and `src/assets/fonts/ibm-plex-serif-600.woff2` once per build, builds the Satori VDOM tree per the visual spec above, runs `satori(...)` to get an SVG string, runs `sharp(svg).png().toBuffer()`, returns the buffer.
+- **`generator.js`** loads `src/assets/img/about-bob.jpg` and the IBM Plex Serif 600 WOFF file from `@fontsource/ibm-plex-serif` (resolved via `createRequire`) once per build, builds the Satori VDOM tree per the visual spec above, runs `satori(...)` to get an SVG string, runs `sharp(svg).png().toBuffer()`, returns the buffer. The site's existing `.woff2` assets aren't reused here because Satori only supports TTF/OTF/WOFF.
 - **`cache.js`** owns `.cache/og/`. Methods:
   - `get(slug, titleHash) -> Buffer | null` — reads `.cache/og/<slug>-<hash>.png` if it exists.
   - `put(slug, titleHash, buffer) -> void` — writes the PNG and updates `manifest.json`.
@@ -115,8 +115,9 @@ build start
 Add to `devDependencies`:
 
 - `satori` — JSX/HTML-to-SVG renderer.
+- `@fontsource/ibm-plex-serif` — provides a WOFF version of IBM Plex Serif 600 in a Satori-compatible format.
 
-`sharp` is already pulled in transitively by `@11ty/eleventy-img` and is used directly to convert Satori's SVG output to PNG.
+`sharp` is already pulled in transitively by `@11ty/eleventy-img` and is used directly to convert Satori's SVG output to PNG. The plan adds it as an explicit `devDependency` so we don't depend on a transitive resolution.
 
 No native deps beyond what's already installed.
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -7,6 +7,9 @@ import addrssid from "./src/_config/utils/addrssid.js";
 // filters
 import filters from "./src/_config/filters/index.js";
 
+// OG image generation
+import registerOgImage from "./src/_config/og-image/index.js";
+
 // plugins
 // import postGraph from "@rknightuk/eleventy-plugin-post-graph";
 import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
@@ -63,6 +66,9 @@ export default function (eleventyConfig) {
 
   // Add local filters
   eleventyConfig.addPlugin(filters);
+
+  // Register OG image generation
+  registerOgImage(eleventyConfig);
 
   // Add & configure external plugins
   eleventyConfig.addPlugin(eleventyImageTransformPlugin, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@11ty/eleventy-plugin-rss": "^2.0.3",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
         "@11ty/is-land": "^4.0.0",
+        "@fontsource/ibm-plex-serif": "^5.2.7",
         "@zachleat/snow-fall": "^1.0.2",
         "dotenv": "^16.0.3",
         "lodash": "^4.17.21",
@@ -27,6 +28,8 @@
         "pagefind": "^1.5.2",
         "path": "^0.12.7",
         "rimraf": "^6.1.2",
+        "satori": "^0.26.0",
+        "sharp": "^0.34.5",
         "wrangler": "^4.86.0"
       }
     },
@@ -198,6 +201,386 @@
         "url": "https://opencollective.com/11ty"
       }
     },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@11ty/eleventy-img/node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -209,6 +592,46 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@11ty/eleventy-img/node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "node_modules/@11ty/eleventy-plugin-bundle": {
@@ -964,6 +1387,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fontsource/ibm-plex-serif": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-serif/-/ibm-plex-serif-5.2.7.tgz",
+      "integrity": "sha512-04owmc2OQQ/DAMjXjEMJc+7V4dBVmR01aIFOg4cuqS8pQ4HbvtlYs/u6+O0vCt21EMx5M/azIbgx43iKyisEOA==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -975,9 +1408,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -994,13 +1427,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -1017,13 +1450,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -1038,9 +1471,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -1055,16 +1488,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1075,16 +1505,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1102,9 +1529,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1122,9 +1546,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1135,16 +1556,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1155,16 +1573,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1175,16 +1590,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1195,16 +1607,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1215,16 +1624,13 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1237,20 +1643,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1263,7 +1666,7 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
@@ -1274,9 +1677,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1300,9 +1700,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1319,16 +1716,13 @@
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1341,20 +1735,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1367,20 +1758,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1393,20 +1781,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1419,13 +1804,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
@@ -1433,7 +1818,7 @@
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.7.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -1463,9 +1848,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -1483,9 +1868,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -1667,6 +2052,23 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -1819,6 +2221,16 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/bcp-47": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
@@ -1892,6 +2304,16 @@
       },
       "engines": {
         "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chokidar": {
@@ -1977,6 +2399,52 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/d": {
@@ -2135,6 +2603,16 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -2405,6 +2883,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2475,6 +2960,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/htmlparser2": {
@@ -2695,6 +3193,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/linkify-it": {
@@ -2928,467 +3437,6 @@
         "node": ">=22.0.0"
       }
     },
-    "node_modules/miniflare/node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
     "node_modules/miniflare/node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -3576,6 +3624,24 @@
         "@pagefind/windows-x64": "1.5.2"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
@@ -3647,6 +3713,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/posthtml": {
       "version": "0.16.7",
@@ -3792,6 +3865,29 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/satori": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
+      "integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -3854,16 +3950,16 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -3872,25 +3968,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/simple-swizzle": {
@@ -3926,6 +4027,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -3952,6 +4060,13 @@
       "engines": {
         "node": ">=0.12"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -4020,6 +4135,17 @@
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/urlpattern-polyfill": {
@@ -4123,6 +4249,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/youch": {
       "version": "4.1.0-beta.10",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@11ty/eleventy-plugin-rss": "^2.0.3",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
     "@11ty/is-land": "^4.0.0",
+    "@fontsource/ibm-plex-serif": "^5.2.7",
     "@zachleat/snow-fall": "^1.0.2",
     "dotenv": "^16.0.3",
     "lodash": "^4.17.21",
@@ -44,6 +45,8 @@
     "pagefind": "^1.5.2",
     "path": "^0.12.7",
     "rimraf": "^6.1.2",
+    "satori": "^0.26.0",
+    "sharp": "^0.34.5",
     "wrangler": "^4.86.0"
   }
 }

--- a/src/_config/og-image/cache.js
+++ b/src/_config/og-image/cache.js
@@ -1,0 +1,109 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+// Bump when the visual spec or generator code changes in a way that
+// should invalidate every previously-cached PNG. The current value
+// is concatenated into the hash input so cached images become stale
+// automatically.
+const RENDERER_VERSION = "1";
+
+const CACHE_DIR = ".cache/og";
+const MANIFEST_PATH = path.join(CACHE_DIR, "manifest.json");
+
+export function hashTitle(title) {
+  return crypto
+    .createHash("sha1")
+    .update(`${RENDERER_VERSION}:${title}`)
+    .digest("hex")
+    .slice(0, 12);
+}
+
+async function ensureDir() {
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+}
+
+async function loadManifest() {
+  try {
+    const raw = await fs.readFile(MANIFEST_PATH, "utf8");
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err.code === "ENOENT") return {};
+    console.warn(`[og-image] manifest unreadable, starting fresh: ${err.message}`);
+    return {};
+  }
+}
+
+async function saveManifest(manifest) {
+  await ensureDir();
+  await fs.writeFile(MANIFEST_PATH, JSON.stringify(manifest, null, 2));
+}
+
+function cacheFileFor(slug, hash) {
+  return path.join(CACHE_DIR, `${slug}-${hash}.png`);
+}
+
+// Returns the cached PNG buffer if the slug+hash matches a stored entry,
+// else null. Errors (file missing, unreadable) are logged and treated
+// as cache miss.
+export async function get(slug, hash) {
+  const manifest = await loadManifest();
+  const entry = manifest[slug];
+  if (!entry || entry.hash !== hash) return null;
+  try {
+    return await fs.readFile(cacheFileFor(slug, hash));
+  } catch (err) {
+    console.warn(`[og-image] cache read failed for ${slug}: ${err.message}`);
+    return null;
+  }
+}
+
+// Writes the buffer to the cache file and updates the manifest.
+// Errors are logged but do not throw — the build proceeds with the
+// freshly-rendered buffer in memory.
+export async function put(slug, hash, buffer) {
+  await ensureDir();
+  const file = `${slug}-${hash}.png`;
+  try {
+    await fs.writeFile(path.join(CACHE_DIR, file), buffer);
+  } catch (err) {
+    console.warn(`[og-image] cache write failed for ${slug}: ${err.message}`);
+    return;
+  }
+  const manifest = await loadManifest();
+  manifest[slug] = { hash, file };
+  await saveManifest(manifest);
+}
+
+// Removes any cache file whose <slug>-<hash> isn't in activeKeys (a Set
+// of "<slug>-<hash>" strings) and prunes orphan manifest entries.
+export async function gc(activeKeys) {
+  let entries;
+  try {
+    entries = await fs.readdir(CACHE_DIR);
+  } catch (err) {
+    if (err.code === "ENOENT") return;
+    console.warn(`[og-image] gc readdir failed: ${err.message}`);
+    return;
+  }
+  for (const name of entries) {
+    if (!name.endsWith(".png")) continue;
+    const key = name.replace(/\.png$/, "");
+    if (!activeKeys.has(key)) {
+      try {
+        await fs.unlink(path.join(CACHE_DIR, name));
+      } catch (err) {
+        console.warn(`[og-image] gc unlink failed for ${name}: ${err.message}`);
+      }
+    }
+  }
+  const manifest = await loadManifest();
+  let dirty = false;
+  for (const [slug, entry] of Object.entries(manifest)) {
+    if (!activeKeys.has(`${slug}-${entry.hash}`)) {
+      delete manifest[slug];
+      dirty = true;
+    }
+  }
+  if (dirty) await saveManifest(manifest);
+}

--- a/src/_config/og-image/cache.js
+++ b/src/_config/og-image/cache.js
@@ -6,7 +6,7 @@ import path from "node:path";
 // should invalidate every previously-cached PNG. The current value
 // is concatenated into the hash input so cached images become stale
 // automatically.
-const RENDERER_VERSION = "1";
+const RENDERER_VERSION = "4";
 
 const CACHE_DIR = ".cache/og";
 const MANIFEST_PATH = path.join(CACHE_DIR, "manifest.json");

--- a/src/_config/og-image/generator.js
+++ b/src/_config/og-image/generator.js
@@ -83,6 +83,22 @@ function buildTree(title, avatarDataUri) {
 						},
 					},
 				},
+				{
+					type: "div",
+					props: {
+						style: {
+							position: "absolute",
+							left: "80px",
+							bottom: "50px",
+							color: "#c7e2f6",
+							fontFamily: "IBM Plex Serif",
+							fontWeight: 600,
+							fontSize: `${Math.round(pickFontSize(title) / 2)}px`,
+							display: "flex",
+						},
+						children: "bobmonsour.com",
+					},
+				},
 			],
 		},
 	};

--- a/src/_config/og-image/generator.js
+++ b/src/_config/og-image/generator.js
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import satori from "satori";
+import sharp from "sharp";
+
+const require = createRequire(import.meta.url);
+
+// Load font and avatar once per process. Both are small (~100KB each)
+// and reused for every render.
+const FONT_PATH = require.resolve(
+	"@fontsource/ibm-plex-serif/files/ibm-plex-serif-latin-600-normal.woff",
+);
+const FONT_DATA = fs.readFileSync(FONT_PATH);
+
+const AVATAR_PATH = path.resolve("src/assets/img/about-bob.jpg");
+const AVATAR_BUFFER = fs.readFileSync(AVATAR_PATH);
+const AVATAR_DATA_URI = `data:image/jpeg;base64,${AVATAR_BUFFER.toString("base64")}`;
+
+// Deterministic font-size ramp keyed to title length. Same title always
+// renders at the same size.
+function pickFontSize(title) {
+	if (title.length <= 60) return 88;
+	if (title.length <= 90) return 72;
+	return 60;
+}
+
+function buildTree(title) {
+	return {
+		type: "div",
+		props: {
+			style: {
+				width: "1200px",
+				height: "630px",
+				backgroundColor: "#353d4d",
+				display: "flex",
+				position: "relative",
+				padding: "80px",
+				boxSizing: "border-box",
+			},
+			children: [
+				{
+					type: "div",
+					props: {
+						style: {
+							color: "#ffffff",
+							fontFamily: "IBM Plex Serif",
+							fontWeight: 600,
+							fontSize: `${pickFontSize(title)}px`,
+							lineHeight: 1.15,
+							letterSpacing: "-0.01em",
+							maxWidth: "880px",
+							display: "flex",
+						},
+						children: title,
+					},
+				},
+				{
+					type: "img",
+					props: {
+						src: AVATAR_DATA_URI,
+						width: 180,
+						height: 180,
+						style: {
+							position: "absolute",
+							bottom: "60px",
+							right: "60px",
+							borderRadius: "9999px",
+							border: "4px solid #c7e2f6",
+						},
+					},
+				},
+			],
+		},
+	};
+}
+
+// Renders the OG image for `title` and returns a PNG Buffer.
+// Throws on font/image load failure, malformed input, or sharp error.
+// Callers should catch and log a warning per the spec's error policy.
+export async function generate(title) {
+	const svg = await satori(buildTree(title), {
+		width: 1200,
+		height: 630,
+		fonts: [
+			{
+				name: "IBM Plex Serif",
+				data: FONT_DATA,
+				weight: 600,
+				style: "normal",
+			},
+		],
+	});
+	return await sharp(Buffer.from(svg)).png().toBuffer();
+}

--- a/src/_config/og-image/generator.js
+++ b/src/_config/og-image/generator.js
@@ -1,21 +1,34 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import satori from "satori";
 import sharp from "sharp";
 
 const require = createRequire(import.meta.url);
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
-// Load font and avatar once per process. Both are small (~100KB each)
-// and reused for every render.
-const FONT_PATH = require.resolve(
-	"@fontsource/ibm-plex-serif/files/ibm-plex-serif-latin-600-normal.woff",
-);
-const FONT_DATA = fs.readFileSync(FONT_PATH);
+// Lazy-loaded once per process and cached. Loading inside generate()
+// (rather than at module import) so any failure is caught by the
+// orchestrator's try/catch and degrades to a per-post warning rather
+// than crashing eleventy.config.js at import time.
+//
+// Note: if the avatar file or its visual treatment changes in a way
+// that should invalidate cached PNGs, bump RENDERER_VERSION in cache.js.
+let assets = null;
 
-const AVATAR_PATH = path.resolve("src/assets/img/about-bob.jpg");
-const AVATAR_BUFFER = fs.readFileSync(AVATAR_PATH);
-const AVATAR_DATA_URI = `data:image/jpeg;base64,${AVATAR_BUFFER.toString("base64")}`;
+function loadAssets() {
+	if (assets) return assets;
+	const fontPath = require.resolve(
+		"@fontsource/ibm-plex-serif/files/ibm-plex-serif-latin-600-normal.woff",
+	);
+	const fontData = fs.readFileSync(fontPath);
+	const avatarPath = path.resolve(moduleDir, "../../assets/img/about-bob.jpg");
+	const avatarBuffer = fs.readFileSync(avatarPath);
+	const avatarDataUri = `data:image/jpeg;base64,${avatarBuffer.toString("base64")}`;
+	assets = { fontData, avatarDataUri };
+	return assets;
+}
 
 // Deterministic font-size ramp keyed to title length. Same title always
 // renders at the same size.
@@ -25,7 +38,7 @@ function pickFontSize(title) {
 	return 60;
 }
 
-function buildTree(title) {
+function buildTree(title, avatarDataUri) {
 	return {
 		type: "div",
 		props: {
@@ -58,7 +71,7 @@ function buildTree(title) {
 				{
 					type: "img",
 					props: {
-						src: AVATAR_DATA_URI,
+						src: avatarDataUri,
 						width: 180,
 						height: 180,
 						style: {
@@ -79,13 +92,14 @@ function buildTree(title) {
 // Throws on font/image load failure, malformed input, or sharp error.
 // Callers should catch and log a warning per the spec's error policy.
 export async function generate(title) {
-	const svg = await satori(buildTree(title), {
+	const { fontData, avatarDataUri } = loadAssets();
+	const svg = await satori(buildTree(title, avatarDataUri), {
 		width: 1200,
 		height: 630,
 		fonts: [
 			{
 				name: "IBM Plex Serif",
-				data: FONT_DATA,
+				data: fontData,
 				weight: 600,
 				style: "normal",
 			},

--- a/src/_config/og-image/index.js
+++ b/src/_config/og-image/index.js
@@ -1,0 +1,62 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { shouldGenerate } from "./rule.js";
+import { generate } from "./generator.js";
+import * as cache from "./cache.js";
+
+// Captured during the data cascade (when we have access to post data),
+// consumed during the after-build hook (when the data cascade is gone).
+// Reset on each build via "eleventy.before".
+let queue = [];
+
+export default function register(eleventyConfig) {
+  eleventyConfig.on("eleventy.before", () => {
+    queue = [];
+  });
+
+  // Capture matching posts during the data cascade. Returning [] means
+  // this collection is empty in templates — we only use the callback
+  // for its side effect of populating `queue`.
+  eleventyConfig.addCollection("ogImageQueue", (api) => {
+    queue = api
+      .getFilteredByGlob("./src/posts/**/*.md")
+      .filter((p) => shouldGenerate(p.data))
+      .map((p) => ({ slug: p.fileSlug, title: p.data.title }));
+    return [];
+  });
+
+  eleventyConfig.on("eleventy.after", async ({ dir }) => {
+    const outDir = path.join(dir.output, "assets/img/og");
+    await fs.mkdir(outDir, { recursive: true });
+
+    const activeKeys = new Set();
+
+    for (const { slug, title } of queue) {
+      const hash = cache.hashTitle(title);
+      activeKeys.add(`${slug}-${hash}`);
+
+      let buf = await cache.get(slug, hash);
+      if (!buf) {
+        try {
+          buf = await generate(title);
+          await cache.put(slug, hash, buf);
+        } catch (err) {
+          console.warn(
+            `[og-image] generation failed for slug=${slug}: ${err.message}`,
+          );
+          continue;
+        }
+      }
+
+      try {
+        await fs.writeFile(path.join(outDir, `${slug}.png`), buf);
+      } catch (err) {
+        console.warn(
+          `[og-image] write to _site failed for slug=${slug}: ${err.message}`,
+        );
+      }
+    }
+
+    await cache.gc(activeKeys);
+  });
+}

--- a/src/_config/og-image/rule.js
+++ b/src/_config/og-image/rule.js
@@ -1,0 +1,8 @@
+// Predicate: should this post receive a generated OG image?
+// A post matches if its tags include neither "notes" nor "til".
+// Used identically by the data cascade hook and the after-build hook
+// so they can never disagree on which posts qualify.
+export function shouldGenerate(data) {
+  const tags = Array.isArray(data?.tags) ? data.tags : [];
+  return !tags.includes("notes") && !tags.includes("til");
+}

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -71,9 +71,9 @@
   <meta property="og:title" content="{{ title }}">
   <meta property="og:type" content="website">
   <meta property="og:description" content="{{ description }}">
-  {% if image and image.source %}
-  <meta property="og:image" content="{{ site.url }}/assets/img/{{ image.source }}">
-  <meta property="og:image:alt" content="{{ image.alt }}">
+  {% if ogImage and ogImage.source %}
+  <meta property="og:image" content="{{ site.url }}/assets/img/{{ ogImage.source }}">
+  <meta property="og:image:alt" content="{{ ogImage.alt }}">
   {% else %}
   <meta property="og:image" content="{{ site.url }}/assets/img/fallback-og-image.png">
   <meta property="og:image:alt" content="Bob Monsour's personal website">

--- a/src/posts/posts.11tydata.js
+++ b/src/posts/posts.11tydata.js
@@ -8,12 +8,33 @@ export default {
       if (data.image && data.image.source) {
         return data.image;
       }
-      if (data.tags.includes("notes")) {
+      if (data.tags?.includes("notes")) {
         return { source: "notes-og-image.jpg" };
       }
-      if (data.tags.includes("til")) {
+      if (data.tags?.includes("til")) {
         return { source: "til-og-image.jpg" };
       }
+    },
+    // OG image (social-share card) is independent of `image` (in-body hero).
+    // Notes and TILs use their dedicated default cards; every other post
+    // uses a build-time-generated card at /assets/img/og/<slug>.png.
+    ogImage: (data) => {
+      if (data.tags?.includes("notes")) {
+        return {
+          source: "notes-og-image.jpg",
+          alt: "Bob Monsour's blog — note",
+        };
+      }
+      if (data.tags?.includes("til")) {
+        return {
+          source: "til-og-image.jpg",
+          alt: "Bob Monsour's blog — TIL",
+        };
+      }
+      return {
+        source: `og/${data.page.fileSlug}.png`,
+        alt: data.title,
+      };
     },
     showImage: true,
     keywords: "retired, web development, blog, eleventy, tennis",


### PR DESCRIPTION
## Summary

Adds build-time generation of per-post Open Graph images for blog posts. Every non-notes/non-TIL post now gets a 1200×630 PNG with the post title (IBM Plex Serif), a round avatar, the site name, and the dark-mode background — written to `_site/assets/img/og/<slug>.png` and referenced by the `og:image` meta tag.

- New self-contained plugin under `src/_config/og-image/` (rule, cache, generator, orchestrator).
- Title-hash cache in `.cache/og/` — first build renders 60 PNGs (~10s); subsequent builds skip via cache. Title changes invalidate the hash → regen.
- Splits OG meta from in-body hero: `image` front matter still drives `showimage.njk`; new computed `ogImage` drives `og:image` only — they no longer compete for the same field.
- Notes/TILs keep their dedicated `notes-og-image.jpg` / `til-og-image.jpg`. Non-post pages (about, books, projects) keep `fallback-og-image.png`.

Renderer: Satori (HTML → SVG) + sharp (SVG → PNG). IBM Plex Serif 600 from `@fontsource/ibm-plex-serif` (Satori doesn't support WOFF2, so we can't reuse the existing `.woff2` in `src/assets/fonts/`).

Spec: `docs/superpowers/specs/2026-05-05-og-image-from-title-design.md`
Plan: `docs/superpowers/plans/2026-05-05-og-image-from-title.md`

## Test plan

- [ ] Run `npm run build`. Confirm `_site/assets/img/og/` has ~60 PNGs.
- [ ] Open one — verify title, avatar bottom-right, "bobmonsour.com" bottom-left, dark background.
- [ ] `grep og:image _site/blog/calculating-reading-time/index.html` → points at `/assets/img/og/calculating-reading-time.png`.
- [ ] `grep og:image _site/blog/<any-notes-post>/index.html` → still points at `notes-og-image.jpg`.
- [ ] `grep og:image _site/about/index.html` → still points at `fallback-og-image.png`.
- [ ] Confirm an existing post with explicit `image:` front matter still shows its hero in the post body, but its `og:image` meta is now the generated card.
- [ ] Run `npm run build` a second time — should be a cache hit (no re-rendering output).
- [ ] Edit any post title in `src/posts/`, rebuild — that one PNG should regenerate (manifest hash changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)